### PR TITLE
Use admonitions from docusaurus

### DIFF
--- a/docs/Advanced/debugging.md
+++ b/docs/Advanced/debugging.md
@@ -1,4 +1,7 @@
 # Debugging BaGetter
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::

--- a/docs/Import/local-feeds.md
+++ b/docs/Import/local-feeds.md
@@ -2,8 +2,11 @@
 
 [Local feeds](https://docs.microsoft.com/en-us/nuget/hosting-packages/local-feeds) let you use a folder as a NuGet package source.
 
-!!! info
-    Please refer to the [BaGetter vs local feeds](../vs/local-feeds.md) page for reasons to upgrade to BaGetter.
+:::info
+
+Please refer to the [BaGetter vs local feeds](../vs/local-feeds.md) page for reasons to upgrade to BaGetter.
+
+:::
 
 ## Steps
 

--- a/docs/Import/nugetorg.md
+++ b/docs/Import/nugetorg.md
@@ -1,7 +1,10 @@
 # Import nuget.org packages
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 ## Mirroring
 

--- a/docs/Import/nugetserver.md
+++ b/docs/Import/nugetserver.md
@@ -2,8 +2,11 @@
 
 [NuGet.Server](https://github.com/NuGet/NuGet.Server) is a lightweight standalone NuGet server. It is strongly recommended that you upgrade to BaGetter if you use NuGet.Server. Feel free to open a [GitHub issue](https://github.com/bagetter/BaGetter/issues) if you need help migrating.
 
-!!! info
-    Please refer to the [BaGetter vs NuGet.Server](../vs/nugetserver.md) page for reasons to upgrade to BaGetter.
+:::info
+
+Please refer to the [BaGetter vs NuGet.Server](../vs/nugetserver.md) page for reasons to upgrade to BaGetter.
+
+:::
 
 ## Steps
 

--- a/docs/Installation/aws.md
+++ b/docs/Installation/aws.md
@@ -1,7 +1,10 @@
 # Run BaGetter on AWS
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 Use Amazon Web Services to scale BaGetter. You can store metadata on [Amazon RDS](https://aws.amazon.com/rds/postgresql/) and upload packages to [Amazon S3](https://aws.amazon.com/s3/).
 
@@ -75,8 +78,11 @@ Publish your first [symbol package](https://docs.microsoft.com/en-us/nuget/creat
 dotnet nuget push -s http://localhost:5000/v3/index.json symbol.package.1.0.0.snupkg
 ```
 
-!!! warning
-    You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+:::warning
+
+You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+
+:::
 
 ## Restore packages
 

--- a/docs/Installation/azure.md
+++ b/docs/Installation/azure.md
@@ -1,7 +1,10 @@
 # Run BaGetter on Azure
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 Use Azure to scale BaGetter. You can store metadata on [Azure SQL Database](https://azure.microsoft.com/en-us/services/sql-database/), upload packages to [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/), and provide powerful search using [Azure Search](https://azure.microsoft.com/en-us/services/search/).
 
@@ -101,8 +104,11 @@ Publish your first [symbol package](https://docs.microsoft.com/en-us/nuget/creat
 dotnet nuget push -s http://localhost:5000/v3/index.json symbol.package.1.0.0.snupkg
 ```
 
-!!! warning
-    You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+:::warning
+
+You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+
+:::
 
 ## Restore packages
 

--- a/docs/Installation/docker.md
+++ b/docs/Installation/docker.md
@@ -18,10 +18,12 @@ Search__Type=Database
 
 For a full list of configurations, please refer to [BaGetter's configuration](../configuration.md) guide.
 
-!!! info
-    The `bagetter.env` file stores [BaGetter's configuration](../configuration) as environment
-    variables. To learn how these configurations work, please refer to
-    [ASP.NET Core's configuration documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1&tabs=basicconfiguration#configuration-by-environment).
+:::info
+
+The `bagetter.env` file stores [BaGetter's configuration](../configuration) as environment variables.
+To learn how these configurations work, please refer to [ASP.NET Core's configuration documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1&tabs=basicconfiguration#configuration-by-environment).
+
+:::
 
 If this step is omitted the default mode (unconfigured) will be Sqlite with the sql blobs stored in the path `/data/db/bagetter.db`.
 
@@ -60,8 +62,12 @@ Publish your first [symbol package](https://docs.microsoft.com/en-us/nuget/creat
 dotnet nuget push -s http://localhost:5000/v3/index.json -k NUGET-SERVER-API-KEY symbol.package.1.0.0.snupkg
 ```
 
-!!! warning
-    The default API Key to publish packages is `NUGET-SERVER-API-KEY`. You should change this to a secret value to secure your server. See [Configure BaGetter](#configure-bagetter).
+:::warning
+
+The default API Key to publish packages is `NUGET-SERVER-API-KEY`.
+You should change this to a secret value to secure your server. See [Configure BaGetter](#configure-bagetter).
+
+:::
 
 ## Browse packages
 

--- a/docs/Installation/gcp.md
+++ b/docs/Installation/gcp.md
@@ -1,7 +1,10 @@
 # Run BaGetter on Google Cloud Platform
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 We're open source and accept contributions!
 [Fork us on GitHub](https://github.com/bagetter/BaGetter).

--- a/docs/Installation/iis-proxy.md
+++ b/docs/Installation/iis-proxy.md
@@ -27,8 +27,12 @@ You **may** need to give special permissions to the top-level BaGetter folder so
 
 ## Alternative storage path
 
-!!! info
-    Virtual Directories do not work with IIS and Kestrel. For more information, please refer to [ASP.NET Core's documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-2.2#virtual-directories).
+:::info
+
+Virtual Directories do not work with IIS and Kestrel.
+For more information, please refer to [ASP.NET Core's documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-2.2#virtual-directories).
+
+:::
 
 Ensure that the configuration's storage `Path` has the appropriate forward slashes:
 

--- a/docs/Installation/local.md
+++ b/docs/Installation/local.md
@@ -25,8 +25,11 @@ Publish your first [symbol package](https://docs.microsoft.com/en-us/nuget/creat
 dotnet nuget push -s http://localhost:5000/v3/index.json symbol.package.1.0.0.snupkg
 ```
 
-!!! warning
-    You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+:::warning
+
+You should secure your server by requiring an API Key to publish packages. For more information, please refer to the [Require an API Key](../configuration.md#require-an-api-key) guide.
+
+:::
 
 ## Restore packages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,11 @@ The following `Mirror` setting configures BaGetter to index packages from [nuget
 }
 ```
 
-!!! info
-    `PackageSource` is the value of the [NuGet service index](https://docs.microsoft.com/en-us/nuget/api/service-index).
+:::info
+
+`PackageSource` is the value of the [NuGet service index](https://docs.microsoft.com/en-us/nuget/api/service-index).
+
+:::
 
 ## Enable package hard deletions
 
@@ -83,8 +86,11 @@ to overwrite the already existing package by setting `AllowPackageOverwrites`:
 
 A private feed requires users to authenticate before accessing packages.
 
-!!! warning
-    Private feeds are not supported at this time! See [this pull request](https://github.com/loic-sharma/BaGet/pull/69) for more information.
+:::warning
+
+Private feeds are not supported at this time! See [this pull request](https://github.com/loic-sharma/BaGet/pull/69) for more information.
+
+:::
 
 ## Database configuration
 

--- a/docs/vs/artifactory.md
+++ b/docs/vs/artifactory.md
@@ -1,4 +1,7 @@
 # Artifactory
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::

--- a/docs/vs/azure-artifacts.md
+++ b/docs/vs/azure-artifacts.md
@@ -1,4 +1,7 @@
 # Azure Artifacts
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::

--- a/docs/vs/liget.md
+++ b/docs/vs/liget.md
@@ -1,7 +1,10 @@
 # LiGet
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 [LiGet](https://github.com/ai-traders/liget) is a NuGet server created with a linux-first approach.
 

--- a/docs/vs/local-feeds.md
+++ b/docs/vs/local-feeds.md
@@ -1,7 +1,10 @@
 # Local Feeds
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 [Local feeds](https://docs.microsoft.com/en-us/nuget/hosting-packages/local-feeds), also known as "folder feeds", let you
 use a folder as a NuGet package source. You can access these packages using a network share.

--- a/docs/vs/myget.md
+++ b/docs/vs/myget.md
@@ -1,4 +1,7 @@
 # MyGet
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::

--- a/docs/vs/nexus.md
+++ b/docs/vs/nexus.md
@@ -1,4 +1,7 @@
 # Nexus
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::

--- a/docs/vs/nugetorg.md
+++ b/docs/vs/nugetorg.md
@@ -1,7 +1,10 @@
 # nuget.org
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 [nuget.org](https://www.nuget.org/), also known as the "Gallery", is the defacto feed to host open
 source packages. You should publish NuGet packages for your open-source projects here.

--- a/docs/vs/nugetserver.md
+++ b/docs/vs/nugetserver.md
@@ -1,7 +1,10 @@
 # NuGet.Server
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::
 
 [NuGet.Server](https://github.com/NuGet/NuGet.Server) is a lightweight standalone NuGet server. It is strongly recommended that you upgrade to BaGetter if you use NuGet.Server. Feel free to open [GitHub issues](https://github.com/bagetter/BaGetter/issues) if you need help migrating.
 

--- a/docs/vs/teamcity.md
+++ b/docs/vs/teamcity.md
@@ -1,4 +1,7 @@
 # TeamCity
 
-!!! warning
-    This page is a work in progress!
+:::warning
+
+This page is a work in progress!
+
+:::


### PR DESCRIPTION
This PR adjusts the documentation to use the admonitions from docusaurus.
See [this documentation](https://docusaurus.io/docs/markdown-features/admonitions) from docusaurus.

Before

![grafik](https://github.com/bagetter/bagetter.github.io/assets/6222752/807c8b86-863b-4f6f-9aab-177e09edf95d)

After

![grafik](https://github.com/bagetter/bagetter.github.io/assets/6222752/accdd1f2-c72d-4d81-a0d1-def77a7016e7)
